### PR TITLE
feat: Support an optional workspace name prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The name of the repo from which to derive a repo TFC workspace name.
 
 The suffix to append to a repo TFC workspace name.
 
+### `workspacePrefix`
+
+A prefix to prepend to the calculated workspace name. **Currently for feature branches only.**
+
 ## Outputs
 
 ### `workspaceName`
@@ -47,9 +51,10 @@ The name of a Terraform Cloud workspace derived from input paramters.
   with:
     type: feature
     featureBranchName: some-branch-name_with-infra
+    workspacePrefix: myproject-
 ```
 
-Produces: `somebranchname`
+Produces: `myproject-somebranchname`
 
 ```yaml
 - uses: cbsinteractive/tfc-workspace-name-action@v1

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Generates a Terraform Cloud workspace name normalized according to conventions u
   - [featureBranchName](#featurebranchname)
   - [repoName](#reponame)
   - [suffix](#suffix)
+  - [workspacePrefix](#workspaceprefix)
 - [Outputs](#outputs)
   - [workspaceName](#workspacename)
 - [Example Usage](#example-usage)

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   suffix:
     description: "The suffix to append to a repo TFC workspace name."
     required: false
+  workspacePrefix:
+    description: "For feature branches, a prefix to prepend to the calculated workspace name."
+    required: false
 outputs:
   workspaceName:
     description: "The name of the derived TFC workspace."

--- a/src/run.js
+++ b/src/run.js
@@ -1,11 +1,14 @@
 module.exports = async (core) => {
   try {
     const workspaceType = core.getInput("type")
+    const workspacePrefix = core.getInput("workspacePrefix", {
+      required: false,
+    })
     let result
     if (workspaceType === "feature") {
-      result = require("./featurebranch").normalize(
-        core.getInput("featureBranchName")
-      )
+      result =
+        workspacePrefix +
+        require("./featurebranch").normalize(core.getInput("featureBranchName"))
     } else if (workspaceType === "repo") {
       result = require("./repo").normalize(
         core.getInput("repoName"),

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -45,6 +45,15 @@ describe("Derives the expected feature workspace names", () => {
       expectedOutput: ["workspaceName", "foo-bar"],
     },
     {
+      description: "Feature branch prefix is supported",
+      getInput: {
+        type: "feature",
+        featureBranchName: "this-is-a-test",
+        workspacePrefix: "foo-",
+      },
+      expectedOutput: ["workspaceName", "foo-thisisatest"],
+    },
+    {
       description:
         "Repo-level workspace; removes dashses from repo name; adds suffix",
       getInput: {
@@ -65,7 +74,7 @@ describe("Derives the expected feature workspace names", () => {
   testTable.forEach((testConfig) => {
     test(testConfig.description, async () => {
       core.getInput.mockImplementation((inputVar) => {
-        return testConfig.getInput[inputVar]
+        return testConfig.getInput[inputVar] || ""
       })
       await run(core)
       if (!testConfig.errorMessage) {


### PR DESCRIPTION
To support the case where multiple projects share a Terraform Cloud
organization, users can now supply a prefix to help identify
what project the workspace belongs to, e.g. "doppler-engine-".

Users are advised to include the trailing dash if they would like the
prefix separated from the calculated workspace name.