### PR TITLE
feat: Add branchToken output

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ A prefix to prepend to the calculated workspace name. **Currently for feature br
 
 The name of a Terraform Cloud workspace derived from input paramters.
 
+### `branchToken`
+
+The branch token portion of the workspace name.
+
 ## Example Usage
 
 ```yaml
@@ -55,7 +59,12 @@ The name of a Terraform Cloud workspace derived from input paramters.
     workspacePrefix: myproject-
 ```
 
-Produces: `myproject-somebranchname`
+Produces:
+
+| Output        | Value                    |
+| ------------- | ------------------------ |
+| workspaceName | myproject-somebranchname |
+| branchToken   | somebranchname           |
 
 ```yaml
 - uses: cbsinteractive/tfc-workspace-name-action@v1
@@ -65,7 +74,11 @@ Produces: `myproject-somebranchname`
     suffix: -prod
 ```
 
-Produces: `myproduct-prod`
+Produces:
+
+| Output        | Value          |
+| ------------- | -------------- |
+| workspaceName | myproduct-prod |
 
 ### Version Selection
 

--- a/action.yml
+++ b/action.yml
@@ -22,3 +22,5 @@ inputs:
 outputs:
   workspaceName:
     description: "The name of the derived TFC workspace."
+  branchToken:
+    description: "The branch token portion of the workspace name."

--- a/src/run.js
+++ b/src/run.js
@@ -5,10 +5,12 @@ module.exports = async (core) => {
       required: false,
     })
     let result
+    let branchToken
     if (workspaceType === "feature") {
-      result =
-        workspacePrefix +
-        require("./featurebranch").normalize(core.getInput("featureBranchName"))
+      branchToken = require("./featurebranch").normalize(
+        core.getInput("featureBranchName")
+      )
+      result = workspacePrefix + branchToken
     } else if (workspaceType === "repo") {
       result = require("./repo").normalize(
         core.getInput("repoName"),
@@ -20,6 +22,9 @@ module.exports = async (core) => {
       )
     }
     core.setOutput("workspaceName", result)
+    if (branchToken) {
+      core.setOutput("branchToken", branchToken)
+    }
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -10,7 +10,7 @@ describe("Derives the expected feature workspace names", () => {
         type: "feature",
         featureBranchName: "JIRA-12345_some-feature_with-infra",
       },
-      expectedOutput: ["workspaceName", "jira12345-somefeature"],
+      expectedOutput: [["workspaceName", "jira12345-somefeature"]],
     },
     {
       description: "Feature branch; removes -with-infra suffix",
@@ -18,7 +18,7 @@ describe("Derives the expected feature workspace names", () => {
         type: "feature",
         featureBranchName: "some-feature-with-infra",
       },
-      expectedOutput: ["workspaceName", "somefeature"],
+      expectedOutput: [["workspaceName", "somefeature"]],
     },
     {
       description: "Feature branch; removes with-infra- prefix",
@@ -26,7 +26,7 @@ describe("Derives the expected feature workspace names", () => {
         type: "feature",
         featureBranchName: "with-infra-some-feature",
       },
-      expectedOutput: ["workspaceName", "somefeature"],
+      expectedOutput: [["workspaceName", "somefeature"]],
     },
     {
       description: "Feature branch; leaves embedded -with-infra- alone",
@@ -34,7 +34,7 @@ describe("Derives the expected feature workspace names", () => {
         type: "feature",
         featureBranchName: "foo-with-infra-bar",
       },
-      expectedOutput: ["workspaceName", "foowithinfrabar"],
+      expectedOutput: [["workspaceName", "foowithinfrabar"]],
     },
     {
       description: "Feature branch; removes embedded _with-infra_ token",
@@ -42,7 +42,7 @@ describe("Derives the expected feature workspace names", () => {
         type: "feature",
         featureBranchName: "foo_with-infra_bar",
       },
-      expectedOutput: ["workspaceName", "foo-bar"],
+      expectedOutput: [["workspaceName", "foo-bar"]],
     },
     {
       description: "Feature branch prefix is supported",
@@ -51,7 +51,19 @@ describe("Derives the expected feature workspace names", () => {
         featureBranchName: "this-is-a-test",
         workspacePrefix: "foo-",
       },
-      expectedOutput: ["workspaceName", "foo-thisisatest"],
+      expectedOutput: [["workspaceName", "foo-thisisatest"]],
+    },
+    {
+      description: "Branch token is supported",
+      getInput: {
+        type: "feature",
+        featureBranchName: "this-is-a-test",
+        workspacePrefix: "foo-",
+      },
+      expectedOutput: [
+        ["workspaceName", "foo-thisisatest"],
+        ["branchToken", "thisisatest"],
+      ],
     },
     {
       description:
@@ -61,7 +73,7 @@ describe("Derives the expected feature workspace names", () => {
         repoName: "some-repo",
         suffix: "-some-suffix",
       },
-      expectedOutput: ["workspaceName", "somerepo-some-suffix"],
+      expectedOutput: [["workspaceName", "somerepo-some-suffix"]],
     },
   ]
   let core
@@ -81,9 +93,12 @@ describe("Derives the expected feature workspace names", () => {
         expect(core.setFailed).not.toHaveBeenCalled()
       }
       if (testConfig.expectedOutput) {
-        expect(core.setOutput).toHaveBeenCalledWith(
-          ...testConfig.expectedOutput
-        )
+        for (let i = 0; i < testConfig.expectedOutput.length; i++) {
+          expect(core.setOutput).toHaveBeenNthCalledWith(
+            i + 1,
+            ...testConfig.expectedOutput[i]
+          )
+        }
       }
     })
   })


### PR DESCRIPTION
In addition to the calculated TFC workspace name, it's useful to have the normalized branch name component as a separate output.